### PR TITLE
Adds an optional consumer that's called whenever a value is set.

### DIFF
--- a/src/main/java/com/lmax/simpledsl/DslParams.java
+++ b/src/main/java/com/lmax/simpledsl/DslParams.java
@@ -67,6 +67,7 @@ public class DslParams extends DslValues
         }
 
         checkAllRequiredParamsSupplied(params);
+        completedParsingArguments();
     }
 
     private boolean matches(final NameValuePair argument, final DslParam param)
@@ -173,6 +174,18 @@ public class DslParams extends DslValues
             arguments[i] = args[i] != null ? new NameValuePair(args[i]) : null;
         }
         return arguments;
+    }
+
+    private void completedParsingArguments()
+    {
+        for (final DslParam param : params)
+        {
+            final SimpleDslParam simpleDslParam = param.getAsSimpleDslParam();
+            if (simpleDslParam != null)
+            {
+                simpleDslParam.completedParsing();
+            }
+        }
     }
 
     private DslParam getDslParam(final String name)

--- a/src/main/java/com/lmax/simpledsl/SimpleDslParam.java
+++ b/src/main/java/com/lmax/simpledsl/SimpleDslParam.java
@@ -18,6 +18,7 @@ package com.lmax.simpledsl;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public abstract class SimpleDslParam extends DslParam
@@ -28,7 +29,7 @@ public abstract class SimpleDslParam extends DslParam
     protected final String name;
     protected boolean allowMultipleValues;
     protected String multipleValueSeparator;
-    private Consumer<String> consumer;
+    private BiConsumer<String, String> consumer;
     private boolean calledConsumer;
 
     public SimpleDslParam(final String name)
@@ -72,6 +73,12 @@ public abstract class SimpleDslParam extends DslParam
     }
 
     public SimpleDslParam setConsumer(Consumer<String> consumer)
+    {
+        this.consumer = (name, value) -> consumer.accept(value);
+        return this;
+    }
+
+    public SimpleDslParam setConsumer(BiConsumer<String, String> consumer)
     {
         this.consumer = consumer;
         return this;
@@ -168,7 +175,7 @@ public abstract class SimpleDslParam extends DslParam
     {
         if (consumer != null)
         {
-            consumer.accept(value);
+            consumer.accept(getName(), value);
             calledConsumer = true;
         }
     }

--- a/src/test/java/com/lmax/simpledsl/DslParamsTest.java
+++ b/src/test/java/com/lmax/simpledsl/DslParamsTest.java
@@ -20,7 +20,9 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -370,7 +372,16 @@ public class DslParamsTest
         assertEquals("Jenny", groups[1].value("group"));
         assertEquals("2", groups[1].value("value"));
         assertEquals("X", groups[1].value("optional"));
+    }
 
+    @Test
+    public void shouldCallConsumerForDefaultValues() throws Exception
+    {
+        final LinkedList<String> list = new LinkedList<>();
+        final Consumer<String> consumer = list::add;
+        final DslParams params = new DslParams(new String[]{}, new OptionalParam("a").setDefault("b").setConsumer(consumer));
+        assertEquals(1, list.size());
+        assertEquals("b", list.get(0));
     }
 
     private void assertDoubleArrayEquals(final double[] expected, final double[] actual)

--- a/src/test/java/com/lmax/simpledsl/OptionalParamTest.java
+++ b/src/test/java/com/lmax/simpledsl/OptionalParamTest.java
@@ -18,6 +18,9 @@ package com.lmax.simpledsl;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.LinkedList;
+import java.util.function.Consumer;
+
 public class OptionalParamTest
 {
     @Test
@@ -52,4 +55,40 @@ public class OptionalParamTest
         Assert.assertEquals(null, param.getValue());
         Assert.assertArrayEquals(new String[0], param.getValues());
     }
+
+    @Test
+    public void consumerIsCalledForSingleValue()
+    {
+        final LinkedList<String> list = new LinkedList<>();
+        final Consumer<String> consumer = list::add;
+        final SimpleDslParam param = new OptionalParam("foo").setConsumer(consumer);
+        param.addValue("abc");
+
+        Assert.assertEquals(1, list.size());
+        Assert.assertEquals("abc", list.get(0));
+    }
+
+    @Test
+    public void consumerIsCalledForDefault()
+    {
+        final LinkedList<String> list = new LinkedList<>();
+        final Consumer<String> consumer = list::add;
+        final SimpleDslParam param = new OptionalParam("foo").setDefault("abc").setConsumer(consumer);
+        param.completedParsing();
+
+        Assert.assertEquals(1, list.size());
+        Assert.assertEquals("abc", list.get(0));
+    }
+
+    @Test
+    public void consumerIsNotCalledForOptionalWithNoDefault()
+    {
+        final LinkedList<String> list = new LinkedList<>();
+        final Consumer<String> consumer = list::add;
+        final SimpleDslParam param = new OptionalParam("foo").setConsumer(consumer);
+        param.completedParsing();
+
+        Assert.assertEquals(0, list.size());
+    }
+
 }

--- a/src/test/java/com/lmax/simpledsl/RequiredParamTest.java
+++ b/src/test/java/com/lmax/simpledsl/RequiredParamTest.java
@@ -18,6 +18,9 @@ package com.lmax.simpledsl;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.LinkedList;
+import java.util.function.Consumer;
+
 public class RequiredParamTest
 {
     @Test
@@ -102,4 +105,17 @@ public class RequiredParamTest
         Assert.assertEquals(4, position);
         Assert.assertArrayEquals(new String[]{"1", "2", "3", "4"}, param.getValues());
     }
+
+    @Test
+    public void consumerIsCalledForSingleValue()
+    {
+        final LinkedList<String> list = new LinkedList<>();
+        final Consumer<String> consumer = list::add;
+        final SimpleDslParam param = new RequiredParam("foo").setConsumer(consumer);
+        param.addValue("abc");
+
+        Assert.assertEquals(1, list.size());
+        Assert.assertEquals("abc", list.get(0));
+    }
+
 }

--- a/src/test/java/com/lmax/simpledsl/SimpleDslParamTest.java
+++ b/src/test/java/com/lmax/simpledsl/SimpleDslParamTest.java
@@ -18,6 +18,9 @@ package com.lmax.simpledsl;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.LinkedList;
+import java.util.function.Consumer;
+
 public class SimpleDslParamTest
 {
     @Test
@@ -84,6 +87,34 @@ public class SimpleDslParamTest
         param.addValue("abc");
         param.addValue("DeF");
         Assert.assertArrayEquals(new String[]{"abc", "def"}, param.getValues());
+    }
+
+    @Test
+    public void consumerIsCalledForSingleValue()
+    {
+        final LinkedList<String> list = new LinkedList<>();
+        final Consumer<String> consumer = list::add;
+        final SimpleDslParam param = new TestParam("foo").setConsumer(consumer);
+        param.addValue("abc");
+
+        Assert.assertEquals(1, list.size());
+        Assert.assertEquals("abc", list.get(0));
+    }
+
+    @Test
+    public void consumerIsCalledForMultipleValuesInCorrectOrder()
+    {
+        final LinkedList<String> list = new LinkedList<>();
+        final Consumer<String> consumer = list::add;
+        final SimpleDslParam param = new TestParam("foo").setAllowMultipleValues().setConsumer(consumer);
+        param.addValue("abc");
+        param.addValue("def");
+        param.addValue("ghi");
+
+        Assert.assertEquals(3, list.size());
+        Assert.assertEquals("abc", list.get(0));
+        Assert.assertEquals("def", list.get(1));
+        Assert.assertEquals("ghi", list.get(2));
     }
 
     private static class TestParam extends SimpleDslParam

--- a/src/test/java/com/lmax/simpledsl/SimpleDslParamTest.java
+++ b/src/test/java/com/lmax/simpledsl/SimpleDslParamTest.java
@@ -19,6 +19,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.LinkedList;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public class SimpleDslParamTest
@@ -115,6 +116,23 @@ public class SimpleDslParamTest
         Assert.assertEquals("abc", list.get(0));
         Assert.assertEquals("def", list.get(1));
         Assert.assertEquals("ghi", list.get(2));
+    }
+
+    @Test
+    public void biConsumerIsCalledWithParameterName()
+    {
+        final LinkedList<String> list = new LinkedList<>();
+        final BiConsumer<String, String> consumer = (name, value) -> list.add(name);
+        final SimpleDslParam param1 = new TestParam("foo").setAllowMultipleValues().setConsumer(consumer);
+        final SimpleDslParam param2 = new TestParam("bar").setAllowMultipleValues().setConsumer(consumer);
+        param1.addValue("abc");
+        param1.addValue("def");
+        param2.addValue("ghi");
+
+        Assert.assertEquals(3, list.size());
+        Assert.assertEquals("foo", list.get(0));
+        Assert.assertEquals("foo", list.get(1));
+        Assert.assertEquals("bar", list.get(2));
     }
 
     private static class TestParam extends SimpleDslParam


### PR DESCRIPTION
This allows for a usage pattern like:
```Java
ValueHolder usernameAlias = new ValueHolder();
ValueHolder passwordAlias = new ValueHolder();

new DslParams(args,
    new RequiredParam("username").setConsumer(usernameAlias),
    new RequiredParam("password").setConsumer(passwordAlias));

String username = testContext.usernames.resolve(usernameAlias.get());
String password = testContext.passwords.resolve(passwordAlias.get());

driver().login(username, password);
```

Or even something like this (which I'd like to implement in [unacceptable](https://github.com/unacceptable/unacceptable)):
```Java
ValueHolder username = new ValueHolder(testContext.usernames);
ValueHolder password = new ValueHolder(testContext.password);

new DslParams(args,
    new RequiredParam("username").setConsumer(username),
    new RequiredParam("password").setConsumer(password));

driver().login(username.get(), password.get());
```

Compared to the current way:
```Java
DslParams params = new DslParams(args,
    new RequiredParam("username")
    new RequiredParam("password"));

String username = testContext.usernames.resolve(params.value("username"));
String password = testContext.passwords.resolve(params.value("password");

driver().login(username, password);
```

I think the new way is more consise, and elliminates duplication of parameter names, particularly in the case of an `OptionalParam` without a default, where one generally ends up doing:
```Java
if (params.hasValue("name"))
{
    String name = params.value("name");
    // do something with name
}
```