### PR TITLE
Adding covariant return types to remove the need for `getAs*` methods.

### DIFF
--- a/src/main/java/com/lmax/simpledsl/DslParam.java
+++ b/src/main/java/com/lmax/simpledsl/DslParam.java
@@ -2,7 +2,11 @@ package com.lmax.simpledsl;
 
 public abstract class DslParam
 {
-    public abstract RequiredParam getAsRequiredParam();
+    /** @deprecated With the addition of covariant return types, this should no longer be necessary. */
+    @Deprecated
+    public RequiredParam getAsRequiredParam() {
+        return null;
+    }
 
     public abstract SimpleDslParam getAsSimpleDslParam();
 
@@ -10,9 +14,9 @@ public abstract class DslParam
 
     public abstract int consume(int currentPosition, NameValuePair... args);
 
-    public final boolean isRequired()
+    public boolean isRequired()
     {
-        return getAsRequiredParam() != null;
+        return false;
     }
 
     public abstract boolean hasValue();

--- a/src/main/java/com/lmax/simpledsl/DslParams.java
+++ b/src/main/java/com/lmax/simpledsl/DslParams.java
@@ -44,7 +44,7 @@ public class DslParams extends DslValues
             {
                 break;
             }
-            currentPosition = param.getAsRequiredParam().consume(currentPosition, arguments);
+            currentPosition = param.consume(currentPosition, arguments);
         }
 
         while (currentPosition < args.length)

--- a/src/main/java/com/lmax/simpledsl/OptionalParam.java
+++ b/src/main/java/com/lmax/simpledsl/OptionalParam.java
@@ -15,7 +15,7 @@
  */
 package com.lmax.simpledsl;
 
-public class OptionalParam extends SimpleDslParam
+public class OptionalParam extends SimpleDslParam<OptionalParam>
 {
     private String defaultValue;
 
@@ -24,14 +24,7 @@ public class OptionalParam extends SimpleDslParam
         super(name);
     }
 
-    @Override
-    public RequiredParam getAsRequiredParam()
-    {
-        return null;
-    }
-
-    @Override
-    public SimpleDslParam setDefault(final String defaultValue)
+    public OptionalParam setDefault(final String defaultValue)
     {
         this.defaultValue = defaultValue;
         return this;

--- a/src/main/java/com/lmax/simpledsl/RepeatingParamGroup.java
+++ b/src/main/java/com/lmax/simpledsl/RepeatingParamGroup.java
@@ -22,12 +22,6 @@ public class RepeatingParamGroup extends DslParam
     }
 
     @Override
-    public RequiredParam getAsRequiredParam()
-    {
-        return null;
-    }
-
-    @Override
     public SimpleDslParam getAsSimpleDslParam()
     {
         return null;

--- a/src/main/java/com/lmax/simpledsl/RequiredParam.java
+++ b/src/main/java/com/lmax/simpledsl/RequiredParam.java
@@ -15,7 +15,7 @@
  */
 package com.lmax.simpledsl;
 
-public class RequiredParam extends SimpleDslParam
+public class RequiredParam extends SimpleDslParam<RequiredParam>
 {
     public RequiredParam(final String name)
     {
@@ -32,6 +32,12 @@ public class RequiredParam extends SimpleDslParam
     public boolean isValid()
     {
         return getValues().length != 0;
+    }
+
+    @Override
+    public boolean isRequired()
+    {
+        return true;
     }
 
     @Override

--- a/src/main/java/com/lmax/simpledsl/SimpleDslParam.java
+++ b/src/main/java/com/lmax/simpledsl/SimpleDslParam.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-public abstract class SimpleDslParam extends DslParam
+public abstract class SimpleDslParam<P extends SimpleDslParam<P>> extends DslParam
 {
     private final List<String> values = new LinkedList<>();
     private static final String DEFAULT_DELIMITER = ",";
@@ -49,39 +49,34 @@ public abstract class SimpleDslParam extends DslParam
         return null;
     }
 
-    public SimpleDslParam setAllowedValues(final String... allowedValues)
+    public P setAllowedValues(final String... allowedValues)
     {
         this.allowedValues = allowedValues;
-        return this;
+        return (P) this;
     }
 
-    public SimpleDslParam setAllowMultipleValues()
+    public P setAllowMultipleValues()
     {
         return setAllowMultipleValues(DEFAULT_DELIMITER);
     }
 
-    public SimpleDslParam setAllowMultipleValues(final String delimiter)
+    public P setAllowMultipleValues(final String delimiter)
     {
         allowMultipleValues = true;
         multipleValueSeparator = delimiter;
-        return this;
+        return (P) this;
     }
 
-    public SimpleDslParam setDefault(final String value)
-    {
-        throw new UnsupportedOperationException("Cannot set default values for this param");
-    }
-
-    public SimpleDslParam setConsumer(Consumer<String> consumer)
+    public P setConsumer(Consumer<String> consumer)
     {
         this.consumer = (name, value) -> consumer.accept(value);
-        return this;
+        return (P) this;
     }
 
-    public SimpleDslParam setConsumer(BiConsumer<String, String> consumer)
+    public P setConsumer(BiConsumer<String, String> consumer)
     {
         this.consumer = consumer;
-        return this;
+        return (P) this;
     }
 
     @Override

--- a/src/test/java/com/lmax/simpledsl/OptionalParamTest.java
+++ b/src/test/java/com/lmax/simpledsl/OptionalParamTest.java
@@ -28,7 +28,6 @@ public class OptionalParamTest
     {
         final DslParam param = new OptionalParam("foo");
         Assert.assertFalse(param.isRequired());
-        Assert.assertNull(param.getAsRequiredParam());
     }
 
     @Test

--- a/src/test/java/com/lmax/simpledsl/RequiredParamTest.java
+++ b/src/test/java/com/lmax/simpledsl/RequiredParamTest.java
@@ -27,7 +27,6 @@ public class RequiredParamTest
     public void aRequiredParamShouldIdentifyItselfAsSuch()
     {
         final DslParam param = new RequiredParam("foo");
-        Assert.assertSame(param, param.getAsRequiredParam());
         Assert.assertTrue(param.isRequired());
     }
 
@@ -79,7 +78,7 @@ public class RequiredParamTest
     @Test
     public void consumeConsumesMultipleParamsUpToTheFirstParamNamedDifferently()
     {
-        final RequiredParam param = new RequiredParam("foo").setAllowMultipleValues().getAsRequiredParam();
+        final RequiredParam param = new RequiredParam("foo").setAllowMultipleValues();
         final int position = param.consume(1, new NameValuePair("first param"), new NameValuePair("foo = 1"), new NameValuePair("2"), new NameValuePair("foo = 3"), new NameValuePair("4"),
                                      new NameValuePair("something else = 5"));
         Assert.assertEquals(5, position);
@@ -89,7 +88,7 @@ public class RequiredParamTest
     @Test
     public void consumeCanConsumeMultipleParamsBySplittingValuesByCommaDelimiter()
     {
-        final RequiredParam param = new RequiredParam("foo").setAllowMultipleValues().getAsRequiredParam();
+        final RequiredParam param = new RequiredParam("foo").setAllowMultipleValues();
         final int position = param.consume(1, new NameValuePair("first param"), new NameValuePair("foo = 1, 2"), new NameValuePair("foo = 3"), new NameValuePair("4"),
                                      new NameValuePair("something else = 5"));
         Assert.assertEquals(4, position);
@@ -99,7 +98,7 @@ public class RequiredParamTest
     @Test
     public void consumeCanConsumeMultipleParamsBySplittingValuesByUserSuppliedDelimiter()
     {
-        final RequiredParam param = new RequiredParam("foo").setAllowMultipleValues("\\|").getAsRequiredParam();
+        final RequiredParam param = new RequiredParam("foo").setAllowMultipleValues("\\|");
         final int position = param.consume(1, new NameValuePair("first param"), new NameValuePair("foo = 1| 2"), new NameValuePair("foo = 3"), new NameValuePair("4"),
                                      new NameValuePair("something else = 5"));
         Assert.assertEquals(4, position);

--- a/src/test/java/com/lmax/simpledsl/SimpleDslParamTest.java
+++ b/src/test/java/com/lmax/simpledsl/SimpleDslParamTest.java
@@ -135,17 +135,11 @@ public class SimpleDslParamTest
         Assert.assertEquals("bar", list.get(2));
     }
 
-    private static class TestParam extends SimpleDslParam
+    private static class TestParam extends SimpleDslParam<TestParam>
     {
         public TestParam(final String name)
         {
             super(name);
-        }
-
-        @Override
-        public RequiredParam getAsRequiredParam()
-        {
-            return null;
         }
 
     }


### PR DESCRIPTION
Also removing `setDefault` from SimpleDslParam since it's specific to OptionalParam.