### PR TITLE
Add extra helper functions for mapping custom data types

### DIFF
--- a/src/main/java/com/lmax/simpledsl/api/DslValues.java
+++ b/src/main/java/com/lmax/simpledsl/api/DslValues.java
@@ -84,6 +84,20 @@ public interface DslValues
     }
 
     /**
+     * Retrieve the value supplied for a parameter, mapping it to the specified {@link Enum}.
+     *
+     * @param name     the name of the parameter.
+     * @param enumType the {@link Enum} type.
+     * @param <T>      the {@link Enum} type.
+     * @return the value supplied for that parameter.
+     * @throws IllegalArgumentException if {@code name} does not match the name of a supported parameter or if the parameter supports multiple values.
+     */
+    default <T extends Enum<T>> T valueAs(final String name, final Class<T> enumType)
+    {
+        return valueAs(name, val -> Enum.valueOf(enumType, val));
+    }
+
+    /**
      * Retrieve the values supplied for a parameter, mapping each provided value using the specified
      * {@link Function function} and returning a {@link Stream} of these values.
      * <p>
@@ -117,6 +131,23 @@ public interface DslValues
     default <T> T[] valuesAs(final String name, final Class<T> type, final Function<String, T> mapper)
     {
         return stream(values(name)).map(mapper).toArray(n -> (T[]) Array.newInstance(type, n));
+    }
+
+    /**
+     * Retrieve the values supplied for a parameter, mapping each provided value using the specified
+     * {@link Function function} and returning an array of these values.
+     * <p>
+     * Returns an empty {@link Stream} if the parameter is optional and a value has not been supplied.
+     *
+     * @param name   the name of the parameter.
+     * @param enumType the {@link Enum} type.
+     * @param <T>      the {@link Enum} type.
+     * @return a {@link Stream} of values supplied for the parameter.
+     * @throws IllegalArgumentException if {@code name} does not match the name of a supported parameter.
+     */
+    default <T extends Enum<T>> T[] valuesAs(final String name, final Class<T> enumType)
+    {
+        return valuesAs(name, enumType, val -> Enum.valueOf(enumType, val));
     }
 
     /**

--- a/src/test/java/com/lmax/simpledsl/internal/DslParamsImplTest.java
+++ b/src/test/java/com/lmax/simpledsl/internal/DslParamsImplTest.java
@@ -58,6 +58,16 @@ public class DslParamsImplTest
     }
 
     @Test
+    public void shouldReturnValueAsAnEnum()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", singletonList("VALUE_1"));
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertEquals(TestValues.VALUE_1, params.valueAs("a", TestValues.class));
+    }
+
+    @Test
     public void shouldReturnMultipleValues()
     {
         final SimpleDslParam aParam = new SimpleDslParam("a", asList("Hello World", "Goodbye, Cruel World"));
@@ -90,6 +100,19 @@ public class DslParamsImplTest
         assertArrayEquals(
                 new TestValues[] {TestValues.VALUE_1, TestValues.VALUE_2},
                 params.valuesAs("a", TestValues.class, TestValues::valueOf)
+        );
+    }
+
+    @Test
+    public void shouldReturnMultipleValuesAsAnEnum()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", asList("VALUE_1", "VALUE_2"));
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertArrayEquals(
+                new TestValues[] {TestValues.VALUE_1, TestValues.VALUE_2},
+                params.valuesAs("a", TestValues.class)
         );
     }
 

--- a/src/test/java/com/lmax/simpledsl/internal/DslParamsImplTest.java
+++ b/src/test/java/com/lmax/simpledsl/internal/DslParamsImplTest.java
@@ -38,37 +38,59 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class DslParamsImplTest
 {
     @Test
-    public void shouldReturnValueAsInt()
+    public void shouldReturnValue()
     {
-        final SimpleDslParam aParam = new SimpleDslParam("a", singletonList("1"));
+        final SimpleDslParam aParam = new SimpleDslParam("a", singletonList("Hello World"));
 
         final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
 
-        assertEquals(1, params.valueAsInt("a"));
+        assertEquals("Hello World", params.value("a"));
     }
 
     @Test
-    public void shouldThrowNumberFormatExceptionWhenValueAsIntCalledForParameterThatIsNotSupplied()
+    public void shouldReturnValueWhenUsingAMappingFunction()
     {
-        final SimpleDslParam aParam = new SimpleDslParam("a", emptyList());
+        final SimpleDslParam aParam = new SimpleDslParam("a", singletonList("VALUE_1"));
 
         final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
 
-        final NumberFormatException exception = assertThrows(
-                NumberFormatException.class,
-                () -> params.valueAsInt("a"));
-
-        assertEquals("null", exception.getMessage());
+        assertEquals(TestValues.VALUE_1, params.valueAs("a", TestValues::valueOf));
     }
 
     @Test
-    public void shouldReturnValueAsLong()
+    public void shouldReturnMultipleValues()
     {
-        final SimpleDslParam aParam = new SimpleDslParam("a", singletonList("1"));
+        final SimpleDslParam aParam = new SimpleDslParam("a", asList("Hello World", "Goodbye, Cruel World"));
 
         final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
 
-        assertEquals(1L, params.valueAsLong("a"));
+        assertArrayEquals(new String[] {"Hello World", "Goodbye, Cruel World"}, params.values("a"));
+    }
+
+    @Test
+    public void shouldReturnMultipleValuesWhenUsingAMappingFunctionToGenericArray()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", asList("VALUE_1", "VALUE_2"));
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertArrayEquals(
+                new Object[] {TestValues.VALUE_1, TestValues.VALUE_2},
+                params.valuesAs("a", TestValues::valueOf)
+        );
+    }
+
+    @Test
+    public void shouldReturnMultipleValuesWhenUsingAMappingFunctionToArrayOfSpecificType()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", asList("VALUE_1", "VALUE_2"));
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertArrayEquals(
+                new TestValues[] {TestValues.VALUE_1, TestValues.VALUE_2},
+                params.valuesAs("a", TestValues.class, TestValues::valueOf)
+        );
     }
 
     @Test
@@ -82,13 +104,59 @@ public class DslParamsImplTest
     }
 
     @Test
-    public void shouldReturnValueAsBigDecimal()
+    public void shouldThrowNullPointerExceptionWhenValueAsBooleanCalledForParameterThatIsNotSupplied()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", emptyList());
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertThrows(
+                NullPointerException.class,
+                () -> params.valueAsBoolean("a"));
+    }
+
+    @Test
+    public void shouldReturnValueAsInt()
     {
         final SimpleDslParam aParam = new SimpleDslParam("a", singletonList("1"));
 
         final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
 
-        assertEquals(0, BigDecimal.ONE.compareTo(params.valueAsBigDecimal("a")));
+        assertEquals(1, params.valueAsInt("a"));
+    }
+
+    @Test
+    public void shouldThrowNullPointerExceptionWhenValueAsIntCalledForParameterThatIsNotSupplied()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", emptyList());
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertThrows(
+                NullPointerException.class,
+                () -> params.valueAsInt("a"));
+    }
+
+    @Test
+    public void shouldReturnValueAsLong()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", singletonList("1"));
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertEquals(1L, params.valueAsLong("a"));
+    }
+
+    @Test
+    public void shouldThrowNullPointerExceptionWhenValueAsLongCalledForParameterThatIsNotSupplied()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", emptyList());
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertThrows(
+                NullPointerException.class,
+                () -> params.valueAsLong("a"));
     }
 
     @Test
@@ -99,6 +167,28 @@ public class DslParamsImplTest
         final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
 
         assertEquals(1.23d, params.valueAsDouble("a"), 0d);
+    }
+
+    @Test
+    public void shouldThrowNullPointerExceptionWhenValueAsDoubleCalledForParameterThatIsNotSupplied()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", emptyList());
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertThrows(
+                NullPointerException.class,
+                () -> params.valueAsDouble("a"));
+    }
+
+    @Test
+    public void shouldReturnValueAsBigDecimal()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", singletonList("1"));
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertEquals(0, BigDecimal.ONE.compareTo(params.valueAsBigDecimal("a")));
     }
 
     @Test
@@ -152,6 +242,16 @@ public class DslParamsImplTest
     }
 
     @Test
+    public void shouldReturnValuesAsDoubleArray()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", asList("1", "2.23", "3"));
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertArrayEquals(new double[]{1, 2.23, 3}, params.valuesAsDoubles("a"));
+    }
+
+    @Test
     public void shouldReturnValuesAsBigDecimalArray()
     {
         final SimpleDslParam aParam = new SimpleDslParam("a", asList("1", "2.23", "3"));
@@ -162,16 +262,6 @@ public class DslParamsImplTest
                 new BigDecimal[]{new BigDecimal("1"), new BigDecimal("2.23"), new BigDecimal("3")},
                 params.valuesAsBigDecimals("a")
         );
-    }
-
-    @Test
-    public void shouldReturnValuesAsDoubleArray()
-    {
-        final SimpleDslParam aParam = new SimpleDslParam("a", asList("1", "2.23", "3"));
-
-        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
-
-        assertArrayEquals(new double[]{1, 2.23, 3}, params.valuesAsDoubles("a"));
     }
 
     @Test
@@ -245,7 +335,87 @@ public class DslParamsImplTest
     }
 
     @Test
-    public void shouldReturnEmptyOptionalWhenMultipleParameterValueIsNotSupplied()
+    public void shouldReturnEmptyOptionalWhenValueIsNotSuppliedAndMappingFunctionIsUsed()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", emptyList());
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertEquals(Optional.empty(), params.valueAsOptionalOf("a", TestValues::valueOf));
+    }
+
+    @Test
+    public void shouldReturnOptionalWithValueWhenValueIsSuppliedAndMappingFunctionIsUsed()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", singletonList("VALUE_1"));
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertEquals(Optional.of(TestValues.VALUE_1), params.valueAsOptionalOf("a", TestValues::valueOf));
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenValueIsNotSupplied()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", emptyList());
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertEquals(emptyList(), params.valuesAsList("a"));
+    }
+
+    @Test
+    public void shouldReturnListWithValueWhenValueIsSupplied()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", singletonList("value"));
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertEquals(singletonList("value"), params.valuesAsList("a"));
+    }
+
+    @Test
+    public void shouldReturnListWithMultipleValuesWhenValuesAreSupplied()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", asList("value1", "value2"));
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertEquals(asList("value1", "value2"), params.valuesAsList("a"));
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenValueIsNotSuppliedAndMappingFunctionIsUsed()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", emptyList());
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertEquals(emptyList(), params.valuesAsListOf("a", TestValues::valueOf));
+    }
+
+    @Test
+    public void shouldReturnListWithValueWhenValueIsSuppliedAndMappingFunctionIsUsed()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", singletonList("VALUE_1"));
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertEquals(singletonList(TestValues.VALUE_1), params.valuesAsListOf("a", TestValues::valueOf));
+    }
+
+    @Test
+    public void shouldReturnListWithMultipleValuesWhenValuesAreSuppliedAndMappingFunctionIsUsed()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", asList("VALUE_1", "VALUE_2"));
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertEquals(asList(TestValues.VALUE_1, TestValues.VALUE_2), params.valuesAsListOf("a", TestValues::valueOf));
+    }
+
+    @Test
+    public void shouldReturnEmptyOptionalListWhenNoValuesAreSupplied()
     {
         final SimpleDslParam aParam = new SimpleDslParam("a", emptyList());
 
@@ -262,5 +432,12 @@ public class DslParamsImplTest
         final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
 
         assertEquals(Optional.of(asList("value1", "value2")), params.valuesAsOptional("a"));
+    }
+
+    private enum TestValues
+    {
+        VALUE_1,
+        VALUE_2,
+        VALUE_3;
     }
 }


### PR DESCRIPTION
There are already convenience methods for mapping `String` values to common data types, e.g. `int`, `long`, `BigDecimal`, etc. With the introduction of lambda expressions in Java 8, there is no reason we cannot extend this to support arbitrary mapping of the `String` values to richer objects.