### PR TITLE
Split multiple values in repeating groups by delimiter 

### DIFF
--- a/src/main/java/com/lmax/simpledsl/internal/DslParamsParser.java
+++ b/src/main/java/com/lmax/simpledsl/internal/DslParamsParser.java
@@ -313,7 +313,7 @@ public class DslParamsParser
                 }
 
                 checkValidValue(arg, argument.value);
-                argValues.add(argument.value);
+                SimpleArgumentProcessor.addValue(arg, argument.value, argValues);
                 arguments.pollFirst();
             }
 

--- a/src/main/java/com/lmax/simpledsl/internal/DslParamsParser.java
+++ b/src/main/java/com/lmax/simpledsl/internal/DslParamsParser.java
@@ -312,7 +312,6 @@ public class DslParamsParser
                     break;
                 }
 
-                checkValidValue(arg, argument.value);
                 SimpleArgumentProcessor.addValue(arg, argument.value, argValues);
                 arguments.pollFirst();
             }

--- a/src/test/java/com/lmax/simpledsl/internal/DslParamsParserTest.java
+++ b/src/test/java/com/lmax/simpledsl/internal/DslParamsParserTest.java
@@ -22,7 +22,6 @@ import com.lmax.simpledsl.api.OptionalArg;
 import com.lmax.simpledsl.api.RepeatingArgGroup;
 import com.lmax.simpledsl.api.RepeatingGroup;
 import com.lmax.simpledsl.api.RequiredArg;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -491,7 +490,6 @@ class DslParamsParserTest
     }
 
     @Test
-    @Disabled("Doesn't work?")
     public void shouldBeAbleToSpecifyMultipleValuesForParamInGroupUsingTheDefaultSeparator()
     {
         final String[] args = {"a: value", "group: Joe", "group: Jenny", "value: 1, 2"};
@@ -518,7 +516,6 @@ class DslParamsParserTest
     }
 
     @Test
-    @Disabled("Doesn't work?")
     public void shouldBeAbleToSpecifyMultipleValuesForParamInGroupUsingACustomSeparator()
     {
         final String[] args = {"a: value", "group: Joe", "group: Jenny", "value: 1;2"};


### PR DESCRIPTION
When using `.setAllowMultipleValues()` for any argument inside a `RepeatingArgGroup`, the current implementation causes any input to not be split by delimiter but instead stored as one string.  Therefore, when retrieving the values as list, it gives one entry containing all values and delimiters.

There are tests showing this that were left as `@Disabled("Doesn't work?")`.

Fixing this so the values are stored as a list and can be accessed as a list.