### PR TITLE
add hasParam api that determines if a parameter has been defined

### DIFF
--- a/src/main/java/com/lmax/simpledsl/api/DslValues.java
+++ b/src/main/java/com/lmax/simpledsl/api/DslValues.java
@@ -50,6 +50,16 @@ public interface DslValues
     boolean hasValue(String name);
 
     /**
+     * Determine if a parameter is defined.
+     * <p>
+     * Returns true when the parameter is defined.
+     *
+     * @param name the name of the parameter.
+     * @return true if the parameter is defined, otherwise false.
+     */
+    boolean hasParam(String name);
+
+    /**
      * Retrieve the value supplied for a parameter.
      * <p>
      * May return {@code null} if the parameter is optional and a value has not been supplied.

--- a/src/main/java/com/lmax/simpledsl/api/DslValues.java
+++ b/src/main/java/com/lmax/simpledsl/api/DslValues.java
@@ -85,6 +85,7 @@ public interface DslValues
      * Determine if a parameter is defined and has a value.
      * <p>
      * Returns true when the parameter is defined and supplied with an empty value.
+     *
      * @param name the name of the parameter.
      * @return true if the parameter is defined and has a value, otherwise false.
      */

--- a/src/main/java/com/lmax/simpledsl/api/DslValues.java
+++ b/src/main/java/com/lmax/simpledsl/api/DslValues.java
@@ -82,6 +82,18 @@ public interface DslValues
     String[] values(String name);
 
     /**
+     * Determine if a parameter is defined and has a value.
+     * <p>
+     * Returns true when the parameter is defined and supplied with an empty value.
+     * @param name the name of the parameter.
+     * @return true if the parameter is defined and has a value, otherwise false.
+     */
+    default boolean hasParamAndValue(String name)
+    {
+        return hasParam(name) && hasValue(name);
+    }
+
+    /**
      * Retrieve the value supplied for a parameter, mapping it using the specified {@link Function function}.
      *
      * @param name   the name of the parameter.

--- a/src/main/java/com/lmax/simpledsl/internal/DslParamsImpl.java
+++ b/src/main/java/com/lmax/simpledsl/internal/DslParamsImpl.java
@@ -67,6 +67,12 @@ final class DslParamsImpl implements DslParams
     }
 
     @Override
+    public boolean hasParam(final String name)
+    {
+        return findDslParam(name).isPresent();
+    }
+
+    @Override
     public DslArg[] getParams()
     {
         return args;

--- a/src/main/java/com/lmax/simpledsl/internal/RepeatingParamValues.java
+++ b/src/main/java/com/lmax/simpledsl/internal/RepeatingParamValues.java
@@ -6,6 +6,8 @@ import com.lmax.simpledsl.api.RepeatingGroup;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Arrays.stream;
+
 class RepeatingParamValues implements RepeatingGroup
 {
     private final DslArg[] dslArgs;
@@ -21,6 +23,12 @@ class RepeatingParamValues implements RepeatingGroup
     public boolean hasValue(final String name)
     {
         return valuesByName.containsKey(name.toLowerCase());
+    }
+
+    @Override
+    public boolean hasParam(final String name)
+    {
+        return stream(dslArgs).anyMatch(arg -> arg.getName().equalsIgnoreCase(name));
     }
 
     @Override

--- a/src/test/java/com/lmax/simpledsl/internal/DslParamsImplTest.java
+++ b/src/test/java/com/lmax/simpledsl/internal/DslParamsImplTest.java
@@ -510,6 +510,27 @@ public class DslParamsImplTest
         assertEquals(Optional.of(asList("value1", "value2")), params.valuesAsOptional("a"));
     }
 
+    @Test
+    public void shouldReturnIfAParamHasBeenDefined()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", asList("value1", "value2"));
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertTrue(params.hasParam("a"));
+        assertFalse(params.hasParam("b"));
+    }
+
+    @Test
+    public void shouldReturnIfAParamHasBeenDefinedCaseInsensitively()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", asList("value1", "value2"));
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertTrue(params.hasParam("A"));
+    }
+
     private enum TestValues
     {
         VALUE_1,

--- a/src/test/java/com/lmax/simpledsl/internal/DslParamsImplTest.java
+++ b/src/test/java/com/lmax/simpledsl/internal/DslParamsImplTest.java
@@ -30,6 +30,7 @@ import java.util.OptionalLong;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -511,13 +512,22 @@ public class DslParamsImplTest
     }
 
     @Test
-    public void shouldReturnIfAParamHasBeenDefined()
+    public void shouldReturnTrueIfAParamHasBeenDefined()
     {
         final SimpleDslParam aParam = new SimpleDslParam("a", asList("value1", "value2"));
 
         final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
 
         assertTrue(params.hasParam("a"));
+    }
+
+    @Test
+    public void shouldReturnFalseIfAParamHasNotBeenDefined()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", asList("value1", "value2"));
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
         assertFalse(params.hasParam("b"));
     }
 
@@ -529,6 +539,45 @@ public class DslParamsImplTest
         final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
 
         assertTrue(params.hasParam("A"));
+    }
+
+    @Test
+    public void shouldReturnTrueIfAParamHasBeenDefinedAndHasAValue()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", asList("value1", "value2"));
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertTrue(params.hasParamAndValue("a"));
+    }
+
+    @Test
+    public void shouldReturnFalseIfAParamHasBeenDefinedButDoesNotHaveAValue()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", emptyList());
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertFalse(params.hasParamAndValue("a"));
+    }
+
+    @Test
+    public void shouldReturnFalseIfAParamHasNotBeenDefinedButDoesNotHaveAValue()
+    {
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], emptyMap());
+
+        assertFalse(params.hasParamAndValue("a"));
+    }
+
+    @Test
+    public void shouldReturnIfAParamHasBeenDefinedHasAValueCaseInsensitively()
+    {
+        final SimpleDslParam aParam = new SimpleDslParam("a", asList("value1", "value2"));
+
+        final DslParams params = new DslParamsImpl(new DslArg[0], Collections.singletonMap("a", aParam));
+
+        assertTrue(params.hasParamAndValue("A"));
     }
 
     private enum TestValues

--- a/src/test/java/com/lmax/simpledsl/internal/RepeatingParamValuesTest.java
+++ b/src/test/java/com/lmax/simpledsl/internal/RepeatingParamValuesTest.java
@@ -1,0 +1,64 @@
+
+/*
+ * Copyright 2011 LMAX Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lmax.simpledsl.internal;
+
+import com.lmax.simpledsl.api.DslArg;
+import com.lmax.simpledsl.api.OptionalArg;
+import com.lmax.simpledsl.api.RequiredArg;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RepeatingParamValuesTest
+{
+    @Test
+    public void shouldReturnIfAParamHasBeenDefined()
+    {
+        final RequiredArg requiredArg = new RequiredArg("foo");
+        final OptionalArg otherArg = new OptionalArg("bar");
+        final Map<String, List<String>> values = new HashMap<>();
+        values.put("foo", Collections.singletonList("abc"));
+        values.put("bar", Collections.singletonList("123"));
+        final RepeatingParamValues params = new RepeatingParamValues(asList(requiredArg, otherArg).toArray(new DslArg[0]), values);
+
+        assertTrue(params.hasParam("foo"));
+        assertTrue(params.hasParam("bar"));
+        assertFalse(params.hasParam("boo"));
+        assertFalse(params.hasParam("far"));
+    }
+
+    @Test
+    public void shouldReturnIfAParamHasBeenDefinedCaseInsensitively()
+    {
+        final RequiredArg requiredArg = new RequiredArg("foo");
+        final OptionalArg otherArg = new OptionalArg("bar");
+        final Map<String, List<String>> values = new HashMap<>();
+        values.put("foo", Collections.singletonList("abc"));
+        values.put("bar", Collections.singletonList("123"));
+        final RepeatingParamValues params = new RepeatingParamValues(asList(requiredArg, otherArg).toArray(new DslArg[0]), values);
+
+        assertTrue(params.hasParam("FOO"));
+        assertTrue(params.hasParam("BaR"));
+    }
+}


### PR DESCRIPTION
Adds the ability to know if a parameter has been defined. 

Before #22, an inconsistency between javadocs and actual implementations meant that `hasValue` returns `false` if the parameter has not been defined, instead of throwing an exception like the javadocs state.

Anyone that exploited that functionality before #22 will then lose that functionality so this PR gives that functionality in a different way.